### PR TITLE
Bump version

### DIFF
--- a/packages/nextra-theme-docs/package.json
+++ b/packages/nextra-theme-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextra-theme-docs-oso",
-  "version": "0.3.0+nextra-2.2.6",
+  "version": "0.3.1+nextra-2.2.6",
   "description": "A Nextra theme for documentation sites.",
   "repository": "https://github.com/shuding/nextra",
   "author": "Shu Ding <g@shud.in>",


### PR DESCRIPTION
Semver ignores everything after the + when comparing version numbers, so we have to bump our version number when we bump the Nextra version number, too.